### PR TITLE
Add comprehensive IGDB game data fields

### DIFF
--- a/server/db/migrations/002_add_igdb_fields.sql
+++ b/server/db/migrations/002_add_igdb_fields.sql
@@ -1,0 +1,31 @@
+-- Add new IGDB fields to games table
+
+-- Story and description
+ALTER TABLE games ADD COLUMN IF NOT EXISTS storyline TEXT;
+
+-- Media
+ALTER TABLE games ADD COLUMN IF NOT EXISTS artworks TEXT[];
+
+-- Game attributes
+ALTER TABLE games ADD COLUMN IF NOT EXISTS game_modes TEXT[];
+ALTER TABLE games ADD COLUMN IF NOT EXISTS player_perspectives TEXT[];
+ALTER TABLE games ADD COLUMN IF NOT EXISTS category INTEGER DEFAULT 0;
+
+-- Ratings and popularity
+ALTER TABLE games ADD COLUMN IF NOT EXISTS rating NUMERIC;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS aggregated_rating NUMERIC;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS rating_count INTEGER DEFAULT 0;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS total_rating_count INTEGER DEFAULT 0;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS hypes INTEGER DEFAULT 0;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS follows INTEGER DEFAULT 0;
+
+-- Metadata
+ALTER TABLE games ADD COLUMN IF NOT EXISTS url VARCHAR(500);
+ALTER TABLE games ADD COLUMN IF NOT EXISTS themes TEXT[];
+ALTER TABLE games ADD COLUMN IF NOT EXISTS keywords TEXT[];
+ALTER TABLE games ADD COLUMN IF NOT EXISTS franchises TEXT[];
+
+-- Complex objects (stored as JSONB)
+ALTER TABLE games ADD COLUMN IF NOT EXISTS involved_companies JSONB;
+ALTER TABLE games ADD COLUMN IF NOT EXISTS age_ratings JSONB;
+

--- a/server/routes/igdb.js
+++ b/server/routes/igdb.js
@@ -105,18 +105,35 @@ router.post('/import/:id', async (req, res) => {
 
     // Insert into local database
     const result = await pool.query(
-      `INSERT INTO games (name, cover, release_date, description, genre, platforms, screenshots, youtube_id, featured, elevation, game_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+      `INSERT INTO games (name, cover, release_date, description, storyline, genre, platforms, screenshots, artworks, youtube_id, category, game_modes, player_perspectives, rating, aggregated_rating, rating_count, total_rating_count, hypes, follows, url, themes, keywords, involved_companies, franchises, age_ratings, featured, elevation, game_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
        RETURNING *`,
       [
         gameData.name,
         gameData.cover,
         gameData.release_date,
         gameData.description,
+        gameData.storyline,
         gameData.genre,
         gameData.platforms,
         gameData.screenshots,
+        gameData.artworks,
         gameData.youtube_id,
+        gameData.category,
+        gameData.game_modes,
+        gameData.player_perspectives,
+        gameData.rating,
+        gameData.aggregated_rating,
+        gameData.rating_count,
+        gameData.total_rating_count,
+        gameData.hypes,
+        gameData.follows,
+        gameData.url,
+        gameData.themes,
+        gameData.keywords,
+        JSON.stringify(gameData.involved_companies),
+        gameData.franchises,
+        JSON.stringify(gameData.age_ratings),
         gameData.featured,
         gameData.elevation,
         gameData.game_id
@@ -170,18 +187,35 @@ router.post('/import-batch', async (req, res) => {
 
         // Insert
         const result = await pool.query(
-          `INSERT INTO games (name, cover, release_date, description, genre, platforms, screenshots, youtube_id, featured, elevation, game_id)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          `INSERT INTO games (name, cover, release_date, description, storyline, genre, platforms, screenshots, artworks, youtube_id, category, game_modes, player_perspectives, rating, aggregated_rating, rating_count, total_rating_count, hypes, follows, url, themes, keywords, involved_companies, franchises, age_ratings, featured, elevation, game_id)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28)
            RETURNING *`,
           [
             gameData.name,
             gameData.cover,
             gameData.release_date,
             gameData.description,
+            gameData.storyline,
             gameData.genre,
             gameData.platforms,
             gameData.screenshots,
+            gameData.artworks,
             gameData.youtube_id,
+            gameData.category,
+            gameData.game_modes,
+            gameData.player_perspectives,
+            gameData.rating,
+            gameData.aggregated_rating,
+            gameData.rating_count,
+            gameData.total_rating_count,
+            gameData.hypes,
+            gameData.follows,
+            gameData.url,
+            gameData.themes,
+            gameData.keywords,
+            JSON.stringify(gameData.involved_companies),
+            gameData.franchises,
+            JSON.stringify(gameData.age_ratings),
             gameData.featured,
             gameData.elevation,
             gameData.game_id

--- a/server/services/igdbService.js
+++ b/server/services/igdbService.js
@@ -91,7 +91,7 @@ class IGDBService {
       query = `search "${searchTerm.trim()}";\n`;
     }
     
-    query += `fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id, rating, aggregated_rating, total_rating_count;\n`;
+    query += `fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id, rating, aggregated_rating, total_rating_count, category, artworks.url, game_modes.name, player_perspectives.name, rating_count, hypes, follows, storyline, url, themes.name, keywords.name, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, franchises.name, age_ratings.rating, age_ratings.category;\n`;
 
     // Year filter - search for games released after a certain year
     if (filters.yearFrom) {
@@ -152,7 +152,7 @@ class IGDBService {
   // Get detailed game information by IGDB game ID
   async getGameById(igdbGameId) {
     const query = `
-      fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id, rating, aggregated_rating;
+      fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id, rating, aggregated_rating, category, artworks.url, game_modes.name, player_perspectives.name, rating_count, hypes, follows, storyline, url, themes.name, keywords.name, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, franchises.name, age_ratings.rating, age_ratings.category;
       where id = ${igdbGameId};
     `;
 
@@ -164,7 +164,7 @@ class IGDBService {
   async getGamesByIds(igdbGameIds) {
     const idsString = igdbGameIds.join(',');
     const query = `
-      fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id;
+      fields name, cover.url, first_release_date, summary, genres.name, platforms.name, screenshots.url, videos.video_id, category, artworks.url, game_modes.name, player_perspectives.name, rating_count, hypes, follows, storyline, url, themes.name, keywords.name, involved_companies.company.name, involved_companies.developer, involved_companies.publisher, franchises.name, age_ratings.rating, age_ratings.category;
       where id = (${idsString});
       limit ${igdbGameIds.length};
     `;
@@ -187,10 +187,34 @@ class IGDBService {
       cover: fixImageUrl(igdbGame.cover?.url),
       release_date: igdbGame.first_release_date || null,
       description: igdbGame.summary || '',
+      storyline: igdbGame.storyline || '',
       genre: igdbGame.genres?.map(g => g.name) || [],
       platforms: igdbGame.platforms?.map(p => p.name) || [],
       screenshots: igdbGame.screenshots?.map(s => fixImageUrl(s.url)) || [],
+      artworks: igdbGame.artworks?.map(a => fixImageUrl(a.url)) || [],
       youtube_id: igdbGame.videos?.map(v => v.video_id) || [],
+      category: igdbGame.category || 0,
+      game_modes: igdbGame.game_modes?.map(m => m.name) || [],
+      player_perspectives: igdbGame.player_perspectives?.map(p => p.name) || [],
+      rating: igdbGame.rating || null,
+      aggregated_rating: igdbGame.aggregated_rating || null,
+      rating_count: igdbGame.rating_count || 0,
+      total_rating_count: igdbGame.total_rating_count || 0,
+      hypes: igdbGame.hypes || 0,
+      follows: igdbGame.follows || 0,
+      url: igdbGame.url || '',
+      themes: igdbGame.themes?.map(t => t.name) || [],
+      keywords: igdbGame.keywords?.map(k => k.name) || [],
+      involved_companies: igdbGame.involved_companies?.map(ic => ({
+        name: ic.company?.name || '',
+        developer: ic.developer || false,
+        publisher: ic.publisher || false
+      })) || [],
+      franchises: igdbGame.franchises?.map(f => f.name) || [],
+      age_ratings: igdbGame.age_ratings?.map(ar => ({
+        rating: ar.rating,
+        category: ar.category
+      })) || [],
       featured: false,
       elevation: 0
     };

--- a/src/pages/DatabasePage.js
+++ b/src/pages/DatabasePage.js
@@ -9,6 +9,7 @@ const DatabasePage = () => {
   const [comments, setComments] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [expandedGame, setExpandedGame] = useState(null);
 
   useEffect(() => {
     fetchDatabaseData();
@@ -153,45 +154,84 @@ const DatabasePage = () => {
                       <th>Platforms</th>
                       <th>Genres</th>
                       <th>Featured</th>
+                      <th>Actions</th>
                     </tr>
                   </thead>
                   <tbody>
                     {games.map((game) => (
-                      <tr key={game.id}>
-                        <td>{game.id}</td>
-                        <td>
-                          <strong>{game.name}</strong>
-                          {game.game_id && (
-                            <div>
-                              <small className='text-muted'>IGDB ID: {game.game_id}</small>
-                            </div>
-                          )}
-                        </td>
-                        <td>
-                          {game.release_date
-                            ? new Date(game.release_date * 1000).toLocaleDateString()
-                            : game.release
-                            ? new Date(game.release * 1000).toLocaleDateString()
-                            : 'Unknown'}
-                        </td>
-                        <td>
-                          {Array.isArray(game.platforms)
-                            ? game.platforms.join(', ')
-                            : game.platforms || 'N/A'}
-                        </td>
-                        <td>
-                          {Array.isArray(game.genre)
-                            ? game.genre.join(', ')
-                            : game.genre || 'N/A'}
-                        </td>
-                        <td>
-                          {game.featured ? (
-                            <Badge color='warning'>Featured</Badge>
-                          ) : (
-                            <span className='text-muted'>-</span>
-                          )}
-                        </td>
-                      </tr>
+                      <>
+                        <tr key={game.id}>
+                          <td>{game.id}</td>
+                          <td>
+                            <strong>{game.name}</strong>
+                            {game.game_id && (
+                              <div>
+                                <small className='text-muted'>IGDB ID: {game.game_id}</small>
+                              </div>
+                            )}
+                          </td>
+                          <td>
+                            {game.release_date
+                              ? new Date(game.release_date * 1000).toLocaleDateString()
+                              : game.release
+                              ? new Date(game.release * 1000).toLocaleDateString()
+                              : 'Unknown'}
+                          </td>
+                          <td>
+                            {Array.isArray(game.platforms)
+                              ? game.platforms.join(', ')
+                              : game.platforms || 'N/A'}
+                          </td>
+                          <td>
+                            {Array.isArray(game.genre)
+                              ? game.genre.join(', ')
+                              : game.genre || 'N/A'}
+                          </td>
+                          <td>
+                            {game.featured ? (
+                              <Badge color='warning'>Featured</Badge>
+                            ) : (
+                              <span className='text-muted'>-</span>
+                            )}
+                          </td>
+                          <td>
+                            <Button 
+                              size='sm' 
+                              color='info' 
+                              onClick={() => setExpandedGame(expandedGame === game.id ? null : game.id)}
+                            >
+                              {expandedGame === game.id ? 'Hide' : 'Details'}
+                            </Button>
+                          </td>
+                        </tr>
+                        {expandedGame === game.id && (
+                          <tr key={`${game.id}-details`}>
+                            <td colSpan='7' style={{ backgroundColor: '#f8f9fa' }}>
+                              <div style={{ padding: '15px' }}>
+                                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '10px' }}>
+                                  <h5 style={{ margin: 0 }}>Full Game Data</h5>
+                                  <Button 
+                                    size='sm' 
+                                    color='secondary' 
+                                    onClick={() => setExpandedGame(null)}
+                                  >
+                                    Close
+                                  </Button>
+                                </div>
+                                <pre style={{ 
+                                  backgroundColor: '#fff', 
+                                  padding: '15px', 
+                                  borderRadius: '5px',
+                                  maxHeight: '500px',
+                                  overflow: 'auto'
+                                }}>
+                                  {JSON.stringify(game, null, 2)}
+                                </pre>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </>
                     ))}
                   </tbody>
                 </Table>


### PR DESCRIPTION
## Summary
Adds 17+ new IGDB fields to enrich game data including storyline, artworks, game modes, themes, developers/publishers, and more.

## Changes
- ✅ Add new IGDB fields: storyline, artworks, game_modes, player_perspectives, category, rating stats, themes, keywords, involved_companies, franchises, age_ratings
- ✅ Create database migration (002_add_igdb_fields.sql) with 17 new columns
- ✅ Update igdbService to fetch all new fields from IGDB API
- ✅ Update import routes to save all new fields to PostgreSQL
- ✅ Add 'Details' button to Database page to inspect full game JSON
- ✅ Store complex fields (involved_companies, age_ratings) as JSONB

## Notes
- Existing games will need to be re-imported to populate new fields
- Local database migration needs to be run on production: `psql $DATABASE_URL -f server/db/migrations/002_add_igdb_fields.sql`